### PR TITLE
Document overhead of encryption

### DIFF
--- a/encryptonize.go
+++ b/encryptonize.go
@@ -92,6 +92,9 @@ func New(keys Keys) (Encryptonize, error) {
 // object that controls access to that data. The calling user is automatically added to the access
 // object. To grant other users access, see AddGroupsToAccess and AddUserToGroups.
 //
+// For all practical purposes, the size of the ciphertext in the SealedObject is len(plaintext) + 48
+// bytes.
+//
 // The sealed object and the sealed access object are not sensitive data.
 func (e *Encryptonize) Encrypt(user *SealedUser, object *Object) (SealedObject, SealedAccess, error) {
 	if !user.verify(e.UserCryptor) {


### PR DESCRIPTION
### Description
Document overhead of encryption. For plaintexts of less than 2^64 bytes, the encoding overhead is 20 bytes, plus 12 bytes for the nonce and 16 bytes for the tag, for a total of 48 bytes.
