### PR TITLE
IO Provider

### DIFF
--- a/encryptonize.go
+++ b/encryptonize.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cyber-crypt-com/encryptonize-lib/crypto"
 	"github.com/cyber-crypt-com/encryptonize-lib/data"
+	"github.com/cyber-crypt-com/encryptonize-lib/io"
 	"github.com/cyber-crypt-com/encryptonize-lib/key"
 )
 
@@ -33,7 +34,9 @@ var ErrNotAuthorized = errors.New("user not authorized")
 // Encryptonize is the entry point to the library. All main functionality is exposed through methods
 // on this struct.
 type Encryptonize struct {
-	keyProvider   key.Provider
+	keyProvider key.Provider
+	ioProvider  io.Provider
+
 	objectCryptor crypto.CryptorInterface
 	accessCryptor crypto.CryptorInterface
 	tokenCryptor  crypto.CryptorInterface
@@ -43,7 +46,7 @@ type Encryptonize struct {
 }
 
 // New creates a new instance of Encryptonize configured with the given providers.
-func New(keyProvider key.Provider) (Encryptonize, error) {
+func New(keyProvider key.Provider, ioProvider io.Provider) (Encryptonize, error) {
 	keys, err := keyProvider.GetKeys()
 	if err != nil {
 		return Encryptonize{}, err
@@ -72,6 +75,7 @@ func New(keyProvider key.Provider) (Encryptonize, error) {
 
 	return Encryptonize{
 		keyProvider:   keyProvider,
+		ioProvider:    ioProvider,
 		objectCryptor: &objectCryptor,
 		accessCryptor: &accessCryptor,
 		tokenCryptor:  &tokenCryptor,
@@ -86,76 +90,107 @@ func New(keyProvider key.Provider) (Encryptonize, error) {
 ////////////////////////////////////////////////////////
 
 // Encrypt creates a new sealed object containing the provided plaintext data as well as an access
-// object that controls access to that data. The calling user is automatically added to the access
-// object. To grant other users access, see AddGroupsToAccess and AddUserToGroups.
+// list that controls access to that data. The calling user is automatically added to the access
+// list. To grant other users access, see AddGroupsToAccess and AddUserToGroups.
+//
+// The returned ID is the unique identifier of the sealed object. It is used to identify the object
+// and related data about the object to the IO Provider, and needs to be provided when decrypting
+// the object.
 //
 // For all practical purposes, the size of the ciphertext in the SealedObject is len(plaintext) + 48
 // bytes.
-//
-// The sealed object and the sealed access object are not sensitive data.
-func (e *Encryptonize) Encrypt(user *data.SealedUser, object *data.Object) (data.SealedObject, data.SealedAccess, error) {
+func (e *Encryptonize) Encrypt(user *data.SealedUser, object *data.Object) (uuid.UUID, error) {
 	if !user.Verify(e.userCryptor) {
-		return data.SealedObject{}, data.SealedAccess{}, ErrNotAuthorized
+		return uuid.Nil, ErrNotAuthorized
 	}
 
-	id, err := uuid.NewV4()
+	oid, err := uuid.NewV4()
 	if err != nil {
-		return data.SealedObject{}, data.SealedAccess{}, err
+		return uuid.Nil, err
 	}
 
-	wrappedOEK, sealedObject, err := object.Seal(id, e.objectCryptor)
+	wrappedOEK, sealedObject, err := object.Seal(oid, e.objectCryptor)
 	if err != nil {
-		return data.SealedObject{}, data.SealedAccess{}, err
+		return uuid.Nil, err
 	}
 
 	access := data.NewAccess(wrappedOEK)
 	access.AddGroups(user.ID)
-	sealedAccess, err := access.Seal(sealedObject.ID, e.accessCryptor)
+	sealedAccess, err := access.Seal(oid, e.accessCryptor)
 	if err != nil {
-		return data.SealedObject{}, data.SealedAccess{}, err
+		return uuid.Nil, err
 	}
 
-	return sealedObject, sealedAccess, nil
+	// Write data to IO Provider
+	if err := e.putSealedObject(&sealedObject, false); err != nil {
+		return uuid.Nil, err
+	}
+	if err := e.putSealedAccess(&sealedAccess, false); err != nil {
+		return uuid.Nil, err
+	}
+
+	return oid, nil
 }
 
 // Update creates a new sealed object containing the provided plaintext data but uses a previously
-// created access object to control access to that data. The authorizing user must be part of the
-// provided access object, either directly or through group membership. The access object is
-// modified in-place, and any object previously associated with this access object can no longer be
-// decrypted.
+// created access list to control access to that data. The authorizing user must be part of the
+// provided access list, either directly or through group membership.
 //
-// The sealed object is not sensitive data.
-func (e *Encryptonize) Update(authorizer *data.SealedUser, object *data.Object, access *data.SealedAccess) (data.SealedObject, error) {
-	plainAccess, err := e.authorizeAccess(authorizer, access)
+// The input ID is the identifier obtained by previously calling Encrypt.
+func (e *Encryptonize) Update(authorizer *data.SealedUser, oid uuid.UUID, object *data.Object) error {
+	access, err := e.getSealedAccess(oid)
 	if err != nil {
-		return data.SealedObject{}, err
+		return err
 	}
 
-	wrappedOEK, sealedObject, err := object.Seal(access.ID, e.objectCryptor)
+	plainAccess, err := e.authorizeAccess(authorizer, access)
 	if err != nil {
-		return data.SealedObject{}, err
+		return err
+	}
+
+	wrappedOEK, sealedObject, err := object.Seal(oid, e.objectCryptor)
+	if err != nil {
+		return err
 	}
 
 	plainAccess.WrappedOEK = wrappedOEK
-	sealedAccess, err := plainAccess.Seal(sealedObject.ID, e.accessCryptor)
+	sealedAccess, err := plainAccess.Seal(oid, e.accessCryptor)
 	if err != nil {
-		return data.SealedObject{}, err
+		return err
 	}
-	*access = sealedAccess
 
-	return sealedObject, nil
+	// Write data to IO Provider
+	if err := e.putSealedObject(&sealedObject, true); err != nil {
+		return err
+	}
+	if err := e.putSealedAccess(&sealedAccess, true); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-// Decrypt extracts the plaintext from a sealed object. The authorizing user must be part of the
-// provided access object, either directly or through group membership.
+// Decrypt fetches a sealed object and extracts the plaintext. The authorizing user must be part of
+// the provided access list, either directly or through group membership.
+//
+// The input ID is the identifier obtained by previously calling Encrypt.
 //
 // The unsealed object may contain sensitive data.
-func (e *Encryptonize) Decrypt(authorizer *data.SealedUser, object *data.SealedObject, access *data.SealedAccess) (data.Object, error) {
+func (e *Encryptonize) Decrypt(authorizer *data.SealedUser, oid uuid.UUID) (data.Object, error) {
+	access, err := e.getSealedAccess(oid)
+	if err != nil {
+		return data.Object{}, err
+	}
+
 	plainAccess, err := e.authorizeAccess(authorizer, access)
 	if err != nil {
 		return data.Object{}, err
 	}
 
+	object, err := e.getSealedObject(oid)
+	if err != nil {
+		return data.Object{}, err
+	}
 	return object.Unseal(plainAccess.WrappedOEK, e.objectCryptor)
 }
 

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -308,17 +308,17 @@ func TestGetAccessGroups(t *testing.T) {
 		AssociatedData: []byte("associated_data"),
 	}
 
-	_, access, err := enc.Encrypt(&user1, &plainObject)
+	id, err := enc.Encrypt(&user1, &plainObject)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = enc.GetAccessGroups(&user1, &access)
+	_, err = enc.GetAccessGroups(&user1, id)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	accessGroups, err := enc.GetAccessGroups(&user2, &access)
+	accessGroups, err := enc.GetAccessGroups(&user2, id)
 	if err == nil {
 		t.Fatal("Unauthorized user able to get group IDs contained in access object")
 	}
@@ -346,16 +346,16 @@ func TestAddRemoveGroupsFromAccess(t *testing.T) {
 		AssociatedData: []byte("associated_data"),
 	}
 
-	_, access, err := enc.Encrypt(&user, &plainObject)
+	id, err := enc.Encrypt(&user, &plainObject)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = enc.AddGroupsToAccess(&user, &access, &group); err != nil {
+	if err = enc.AddGroupsToAccess(&user, id, &group); err != nil {
 		t.Fatal(err)
 	}
 
-	accessGroups, err := enc.GetAccessGroups(&user, &access)
+	accessGroups, err := enc.GetAccessGroups(&user, id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,11 +363,11 @@ func TestAddRemoveGroupsFromAccess(t *testing.T) {
 		t.Fatal("Group not correctly added to access object")
 	}
 
-	if err = enc.RemoveGroupsFromAccess(&user, &access, &group); err != nil {
+	if err = enc.RemoveGroupsFromAccess(&user, id, &group); err != nil {
 		t.Fatal(err)
 	}
 
-	accessGroups, err = enc.GetAccessGroups(&user, &access)
+	accessGroups, err = enc.GetAccessGroups(&user, id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,20 +400,20 @@ func TestAddRemoveGroupsFromAccessUnauthorized(t *testing.T) {
 		AssociatedData: []byte("associated_data"),
 	}
 
-	_, access, err := enc.Encrypt(&user1, &plainObject)
+	id, err := enc.Encrypt(&user1, &plainObject)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = enc.AddGroupsToAccess(&user2, &access, &group); err == nil {
+	if err = enc.AddGroupsToAccess(&user2, id, &group); err == nil {
 		t.Fatal("Unauthorized user able to add groups to access")
 	}
 
-	if err = enc.AddGroupsToAccess(&user1, &access, &group); err != nil {
+	if err = enc.AddGroupsToAccess(&user1, id, &group); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = enc.RemoveGroupsFromAccess(&user2, &access, &group); err == nil {
+	if err = enc.RemoveGroupsFromAccess(&user2, id, &group); err == nil {
 		t.Fatal("Unauthorized user able to remove groups from access")
 	}
 }
@@ -438,16 +438,16 @@ func TestAddRemoveGroupsFromAccessAuthorized(t *testing.T) {
 		AssociatedData: []byte("associated_data"),
 	}
 
-	_, access, err := enc.Encrypt(&user1, &plainObject)
+	id, err := enc.Encrypt(&user1, &plainObject)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = enc.AddGroupsToAccess(&user1, &access, &group2); err != nil {
+	if err = enc.AddGroupsToAccess(&user1, id, &group2); err != nil {
 		t.Fatal(err)
 	}
 
-	accessGroups, err := enc.GetAccessGroups(&user1, &access)
+	accessGroups, err := enc.GetAccessGroups(&user1, id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,11 +455,11 @@ func TestAddRemoveGroupsFromAccessAuthorized(t *testing.T) {
 		t.Fatal("User not able to add groups to access object. User is not member of all groups, but is part of access object.")
 	}
 
-	if err = enc.RemoveGroupsFromAccess(&user1, &access, &group2); err != nil {
+	if err = enc.RemoveGroupsFromAccess(&user1, id, &group2); err != nil {
 		t.Fatal(err)
 	}
 
-	accessGroups, err = enc.GetAccessGroups(&user1, &access)
+	accessGroups, err = enc.GetAccessGroups(&user1, id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestAddInvalidGroupsToAccess(t *testing.T) {
 		AssociatedData: []byte("associated_data"),
 	}
 
-	_, access, err := enc.Encrypt(&user, &plainObject)
+	id, err := enc.Encrypt(&user, &plainObject)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -495,7 +495,7 @@ func TestAddInvalidGroupsToAccess(t *testing.T) {
 	// Make group invalid by changing its ciphertext
 	copy(group.Ciphertext[:5], make([]byte, 5))
 
-	if err = enc.AddGroupsToAccess(&user, &access, &group); err == nil {
+	if err = enc.AddGroupsToAccess(&user, id, &group); err == nil {
 		t.Fatal("User able to add invalid groups to access")
 	}
 }
@@ -519,19 +519,19 @@ func TestRemoveInvalidGroupsFromAccess(t *testing.T) {
 		AssociatedData: []byte("associated_data"),
 	}
 
-	_, access, err := enc.Encrypt(&user, &plainObject)
+	id, err := enc.Encrypt(&user, &plainObject)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = enc.AddGroupsToAccess(&user, &access, &group); err != nil {
+	if err = enc.AddGroupsToAccess(&user, id, &group); err != nil {
 		t.Fatal(err)
 	}
 
 	// Make group invalid by changing its ciphertext
 	copy(group.Ciphertext[:5], make([]byte, 5))
 
-	if err = enc.RemoveGroupsFromAccess(&user, &access, &group); err == nil {
+	if err = enc.RemoveGroupsFromAccess(&user, id, &group); err == nil {
 		t.Fatal("User able to remove invalid groups from access")
 	}
 }
@@ -559,23 +559,23 @@ func TestAuthorizeUser(t *testing.T) {
 		AssociatedData: []byte("associated_data"),
 	}
 
-	_, access, err := enc.Encrypt(&user1, &plainObject)
+	id, err := enc.Encrypt(&user1, &plainObject)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = enc.AuthorizeUser(&user1, &access); err != nil {
+	if err = enc.AuthorizeUser(&user1, id); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = enc.AuthorizeUser(&user2, &access); err == nil {
+	if err = enc.AuthorizeUser(&user2, id); err == nil {
 		t.Fatal("Unauthorized user is authorized anyway")
 	}
 
 	// Make user1 unauthorized by changing its first 5 ciphertext bytes to 0
 	copy(user1.Ciphertext[:5], make([]byte, 5))
 
-	if err = enc.AuthorizeUser(&user1, &access); err == nil {
+	if err = enc.AuthorizeUser(&user1, id); err == nil {
 		t.Fatal("Unauthorized user is authorized anyway")
 	}
 }
@@ -1146,7 +1146,7 @@ func TestRemoveAccess(t *testing.T) {
 		AssociatedData: []byte("associated_data"),
 	}
 
-	_, access, err := enc.Encrypt(&user, &plainObject)
+	id, err := enc.Encrypt(&user, &plainObject)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1155,7 +1155,7 @@ func TestRemoveAccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = enc.AuthorizeUser(&user, &access); err == nil {
+	if err = enc.AuthorizeUser(&user, id); err == nil {
 		t.Fatal("Unauthorized user is authorized anyway")
 	}
 }

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cyber-crypt-com/encryptonize-lib"
 	"github.com/cyber-crypt-com/encryptonize-lib/data"
+	"github.com/cyber-crypt-com/encryptonize-lib/io"
 	"github.com/cyber-crypt-com/encryptonize-lib/key"
 )
 
@@ -33,10 +34,13 @@ var keyProvider = key.NewStatic(key.Keys{
 	IEK: []byte{5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
 })
 
+// Store encrypted data in memory.
+var ioProvider = io.NewMem()
+
 // This is a basic example demonstrating how to use the Encryptonize® library to encrypt and decrypt binary data.
 func Example_basicEncryptDecrypt() {
 	// Instantiate the Encryptonize® library with the given keys.
-	ectnz, err := encryptonize.New(&keyProvider)
+	ectnz, err := encryptonize.New(&keyProvider, &ioProvider)
 	if err != nil {
 		log.Fatalf("Error instantiating Encryptonize: %v", err)
 	}
@@ -53,16 +57,15 @@ func Example_basicEncryptDecrypt() {
 		AssociatedData: []byte("AssociatedData"),
 	}
 
-	// Encrypt the object and get the corresponding encrypted access object. The access object is required for decryption as its ciphertext contains
-	// the wrapped object encryption key and the IDs of the users that are allowed to decrypt the corresponding object. By default, only the default
-	// group of the user who encrypted the object is allowed to decrypt the object.
-	encryptedObject, encryptedAccess, err := ectnz.Encrypt(&user, &binaryObject)
+	// Encrypt the object and get the resulting object ID. By default, only the default group of the
+	// user who encrypted the object is allowed to decrypt the object.
+	oid, err := ectnz.Encrypt(&user, &binaryObject)
 	if err != nil {
 		log.Fatalf("Error encrypting object: %v", err)
 	}
 
-	// Decrypt the object with the corresponding access using the given user as the authorizer.
-	decryptedObject, err := ectnz.Decrypt(&user, &encryptedObject, &encryptedAccess)
+	// Decrypt the object using the given user as the authorizer.
+	decryptedObject, err := ectnz.Decrypt(&user, oid)
 	if err != nil {
 		log.Fatalf("Error decrypting object: %v", err)
 	}

--- a/example_token_test.go
+++ b/example_token_test.go
@@ -23,7 +23,7 @@ import (
 
 func ExampleEncryptonize_CreateToken() {
 	// Instantiate the Encryptonize® library with the given keys.
-	ectnz, err := encryptonize.New(&keyProvider)
+	ectnz, err := encryptonize.New(&keyProvider, &ioProvider)
 	if err != nil {
 		log.Fatalf("Error instantiating Encryptonize: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/gofrs/uuid v4.2.0+incompatible
+	go.etcd.io/bbolt v1.3.6
 	golang.org/x/crypto v0.0.0-20220210151621-f4118a5b28e2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,11 @@
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
+go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 golang.org/x/crypto v0.0.0-20220210151621-f4118a5b28e2 h1:XdAboW3BNMv9ocSCOk/u1MFioZGzCNkiJZ19v9Oe3Ig=
 golang.org/x/crypto v0.0.0-20220210151621-f4118a5b28e2/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=

--- a/io/bolt.go
+++ b/io/bolt.go
@@ -1,0 +1,77 @@
+package io
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+	bolt "go.etcd.io/bbolt"
+)
+
+// Mem implements an IO Provider backed by the key/value database bolt..
+type Bolt struct {
+	store *bolt.DB
+}
+
+// NewBolt creates a new IO Provider that stores its data in the specified file.
+func NewBolt(path string) (Bolt, error) {
+	store, err := bolt.Open(path, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		return Bolt{}, err
+	}
+
+	// Create one bucket per data type
+	err = store.Update(func(tx *bolt.Tx) error {
+		for t := DataType(0); t < DataTypeEnd; t++ {
+			_, err := tx.CreateBucketIfNotExists(t.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return Bolt{}, err
+	}
+
+	return Bolt{store}, nil
+}
+
+func (b *Bolt) Put(id uuid.UUID, dataType DataType, data []byte) error {
+	return b.store.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(dataType.Bytes())
+		return b.Put(id.Bytes(), data)
+	})
+}
+
+func (b *Bolt) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
+	var out []byte
+	err := b.store.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(dataType.Bytes())
+		out = append(out, b.Get(id.Bytes())...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, ErrNotFound
+	}
+	return out, nil
+}
+
+func (b *Bolt) Update(id uuid.UUID, dataType DataType, data []byte) error {
+	return b.store.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(dataType.Bytes())
+		if b.Get(id.Bytes()) == nil {
+			return ErrNotFound
+		}
+		return b.Put(id.Bytes(), data)
+	})
+}
+
+func (b *Bolt) Delete(id uuid.UUID, dataType DataType) error {
+	return b.store.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(dataType.Bytes())
+		return b.Delete(id.Bytes())
+	})
+}

--- a/io/bolt_test.go
+++ b/io/bolt_test.go
@@ -1,0 +1,159 @@
+package io
+
+import (
+	"testing"
+
+	"bytes"
+	"errors"
+
+	"github.com/gofrs/uuid"
+)
+
+// Test that putting and subsequently getting data returns the right bytes for all data types.
+func TestBoltPutAndGet(t *testing.T) {
+	bolt, err := NewBolt(t.TempDir() + "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := []byte("mock data")
+	id := uuid.Must(uuid.NewV4())
+
+	for dt := DataType(0); dt < DataTypeEnd; dt++ {
+		testData := append(data, dt.Bytes()...)
+		err := bolt.Put(id, dt, testData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fetched, err := bolt.Get(id, dt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(testData, fetched) {
+			t.Fatalf("returned data (%+v) not equal to original (%+v)", fetched, data)
+		}
+	}
+}
+
+// Test that getting non-existing data returns the right error.
+func TestBoltNotFound(t *testing.T) {
+	bolt, err := NewBolt(t.TempDir() + "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id := uuid.Must(uuid.NewV4())
+
+	data, err := bolt.Get(id, DataTypeSealedObject)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Expected %v but got %v", ErrNotFound, err)
+	}
+	if data != nil {
+		t.Fatalf("Expected data to be nil but got %v", data)
+	}
+}
+
+// Test that using an invalid file path fails.
+func TestBoltInvalidPath(t *testing.T) {
+	_, err := NewBolt("/../../../not/a/valid/path")
+	if err == nil {
+		t.Fatal("Expected NewBolt to fail on invalid path")
+	}
+}
+
+// Test that data can be updated correctly.
+func TestBoltUpdate(t *testing.T) {
+	bolt, err := NewBolt(t.TempDir() + "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := []byte("mock data")
+	updated := []byte("updated mock data")
+	id := uuid.Must(uuid.NewV4())
+
+	for dt := DataType(0); dt < DataTypeEnd; dt++ {
+		err := bolt.Put(id, dt, append(data, dt.Bytes()...))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testUpdated := append(updated, dt.Bytes()...)
+		err = bolt.Update(id, dt, testUpdated)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fetched, err := bolt.Get(id, dt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(testUpdated, fetched) {
+			t.Fatalf("returned data (%+v) not equal to original (%+v)", fetched, data)
+		}
+	}
+}
+
+// Test that updating data that doesn't exist errors correctly.
+func TestBoltUpdateNotFound(t *testing.T) {
+	bolt, err := NewBolt(t.TempDir() + "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id := uuid.Must(uuid.NewV4())
+
+	err = bolt.Update(id, DataTypeSealedObject, []byte("mock data"))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Expected %v but got %v", ErrNotFound, err)
+	}
+}
+
+// Test that deleting data actually removes it.
+func TestBoltDelete(t *testing.T) {
+	bolt, err := NewBolt(t.TempDir() + "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := []byte("mock data")
+	id := uuid.Must(uuid.NewV4())
+
+	for dt := DataType(0); dt < DataTypeEnd; dt++ {
+		err := bolt.Put(id, dt, append(data, dt.Bytes()...))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = bolt.Delete(id, dt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := bolt.Get(id, dt)
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("Expected %v but got %v", ErrNotFound, err)
+		}
+		if data != nil {
+			t.Fatalf("Expected data to be nil but got %v", data)
+		}
+	}
+}
+
+// Test that deleting non-existing data doesn't error.
+func TestBoltDeleteNotFound(t *testing.T) {
+	bolt, err := NewBolt(t.TempDir() + "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id := uuid.Must(uuid.NewV4())
+
+	err = bolt.Delete(id, DataTypeSealedObject)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/io/io.go
+++ b/io/io.go
@@ -1,0 +1,51 @@
+// Package io contains the definition of the IO Provider, as well as various implementations of
+// the concept.
+package io
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/gofrs/uuid"
+)
+
+// Error returned if data is not found during a "Get" or "Update" call.
+var ErrNotFound = errors.New("not found")
+
+// Types of data supported by an IO Provider.
+type DataType uint16
+
+const (
+	DataTypeSealedObject DataType = iota
+	DataTypeSealedAccess
+	DataTypeEnd
+)
+
+// Bytes returns a byte representation of a DataType..
+func (d DataType) Bytes() []byte {
+	b := make([]byte, binary.MaxVarintLen16)
+	binary.LittleEndian.PutUint16(b, uint16(d))
+	return b
+}
+
+// String returns a string representation of a DataType.
+func (d DataType) String() string {
+	return fmt.Sprintf("%d", d)
+}
+
+// Provider is the interface an IO Provider must implement to handle data from Encryptonize.
+type Provider interface {
+	// Put sends bytes to the IO Provider. The data is identified by an ID and a data type.
+	Put(id uuid.UUID, dataType DataType, data []byte) error
+
+	// Get fetches data from the IO Provider. The data is identified by an ID and a data type.
+	Get(id uuid.UUID, dataType DataType) ([]byte, error)
+
+	// Update is similar to Put but updates data previously sent to the IO Provider. Should error if
+	// the data does not exist in the IO Provider.
+	Update(id uuid.UUID, dataType DataType, data []byte) error
+
+	// Delete removes data previously sent to the IO Provider.
+	Delete(id uuid.UUID, dataType DataType) error
+}

--- a/io/mem.go
+++ b/io/mem.go
@@ -1,0 +1,44 @@
+package io
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/gofrs/uuid"
+)
+
+// Mem implements an in-memory version of an IO Provider.
+type Mem struct {
+	data sync.Map
+}
+
+// NewMem creates a new in-memory IO Provider.
+func NewMem() Mem {
+	return Mem{sync.Map{}}
+}
+
+func (m *Mem) Put(id uuid.UUID, dataType DataType, data []byte) error {
+	m.data.Store(fmt.Sprintf("%s:%s", id.String(), dataType.String()), data)
+	return nil
+}
+
+func (m *Mem) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
+	out, ok := m.data.Load(fmt.Sprintf("%s:%s", id.String(), dataType.String()))
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return out.([]byte), nil
+}
+
+func (m *Mem) Update(id uuid.UUID, dataType DataType, data []byte) error {
+	_, err := m.Get(id, dataType)
+	if err != nil {
+		return err
+	}
+	return m.Put(id, dataType, data)
+}
+
+func (m *Mem) Delete(id uuid.UUID, dataType DataType) error {
+	m.data.Delete(fmt.Sprintf("%s:%s", id.String(), dataType.String()))
+	return nil
+}

--- a/io/mem_test.go
+++ b/io/mem_test.go
@@ -1,0 +1,133 @@
+package io
+
+import (
+	"testing"
+
+	"bytes"
+	"errors"
+
+	"github.com/gofrs/uuid"
+)
+
+// Test that putting and subsequently getting data returns the right bytes for all data types.
+func TestMemPutAndGet(t *testing.T) {
+	mem := NewMem()
+
+	data := []byte("mock data")
+	id := uuid.Must(uuid.NewV4())
+
+	for dt := DataType(0); dt < DataTypeEnd; dt++ {
+		testData := append(data, dt.Bytes()...)
+		err := mem.Put(id, dt, testData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fetched, err := mem.Get(id, dt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(testData, fetched) {
+			t.Fatalf("returned data (%+v) not equal to original (%+v)", fetched, data)
+		}
+	}
+}
+
+// Test that getting non-existing data returns the right error.
+func TestMemNotFound(t *testing.T) {
+	mem := NewMem()
+
+	id := uuid.Must(uuid.NewV4())
+
+	data, err := mem.Get(id, DataTypeSealedObject)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Expected %v but got %v", ErrNotFound, err)
+	}
+	if data != nil {
+		t.Fatalf("Expected data to be nil but got %v", data)
+	}
+}
+
+// Test that data can be updated correctly.
+func TestMemUpdate(t *testing.T) {
+	mem := NewMem()
+
+	data := []byte("mock data")
+	updated := []byte("updated mock data")
+	id := uuid.Must(uuid.NewV4())
+
+	for dt := DataType(0); dt < DataTypeEnd; dt++ {
+		err := mem.Put(id, dt, append(data, dt.Bytes()...))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testUpdated := append(updated, dt.Bytes()...)
+		err = mem.Update(id, dt, testUpdated)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fetched, err := mem.Get(id, dt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(testUpdated, fetched) {
+			t.Fatalf("returned data (%+v) not equal to original (%+v)", fetched, data)
+		}
+	}
+}
+
+// Test that updating data that doesn't exist errors correctly.
+func TestMemUpdateNotFound(t *testing.T) {
+	mem := NewMem()
+
+	id := uuid.Must(uuid.NewV4())
+
+	err := mem.Update(id, DataTypeSealedObject, []byte("mock data"))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Expected %v but got %v", ErrNotFound, err)
+	}
+}
+
+// Test that deleting data actually removes it.
+func TestMemDelete(t *testing.T) {
+	mem := NewMem()
+
+	data := []byte("mock data")
+	id := uuid.Must(uuid.NewV4())
+
+	for dt := DataType(0); dt < DataTypeEnd; dt++ {
+		err := mem.Put(id, dt, append(data, dt.Bytes()...))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = mem.Delete(id, dt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := mem.Get(id, dt)
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("Expected %v but got %v", ErrNotFound, err)
+		}
+		if data != nil {
+			t.Fatalf("Expected data to be nil but got %v", data)
+		}
+	}
+}
+
+// Test that deleting non-existing data doesn't error.
+func TestMemDeleteNotFound(t *testing.T) {
+	mem := NewMem()
+
+	id := uuid.Must(uuid.NewV4())
+
+	err := mem.Delete(id, DataTypeSealedObject)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/utility.go
+++ b/utility.go
@@ -15,11 +15,14 @@
 package encryptonize
 
 import (
+	"bytes"
+	"encoding/gob"
 	"errors"
 
 	"github.com/gofrs/uuid"
 
 	"github.com/cyber-crypt-com/encryptonize-lib/data"
+	"github.com/cyber-crypt-com/encryptonize-lib/io"
 )
 
 // authorizeAccess checks whether the authorizing user is allowed to access the provided access
@@ -73,4 +76,70 @@ func (e *Encryptonize) verifyGroups(groups ...*data.SealedGroup) ([]uuid.UUID, e
 		groupIDs = append(groupIDs, group.ID)
 	}
 	return groupIDs, nil
+}
+
+// putSealedObject encodes a sealed object and sends it to the IO Provider, either as a "Put" or an
+// "Update".
+func (e *Encryptonize) putSealedObject(object *data.SealedObject, update bool) error {
+	var objectBuffer bytes.Buffer
+	enc := gob.NewEncoder(&objectBuffer)
+	if err := enc.Encode(object); err != nil {
+		return err
+	}
+
+	if update {
+		return e.ioProvider.Update(object.ID, io.DataTypeSealedObject, objectBuffer.Bytes())
+	}
+	return e.ioProvider.Put(object.ID, io.DataTypeSealedObject, objectBuffer.Bytes())
+}
+
+// getSealedObject fetches bytes from the IO Provider and decodes them into a sealed object.
+func (e *Encryptonize) getSealedObject(id uuid.UUID) (*data.SealedObject, error) {
+	objectBytes, err := e.ioProvider.Get(id, io.DataTypeSealedObject)
+	if err != nil {
+		return nil, err
+	}
+
+	object := &data.SealedObject{}
+	dec := gob.NewDecoder(bytes.NewReader(objectBytes))
+	err = dec.Decode(object)
+	if err != nil {
+		return nil, err
+	}
+
+	object.ID = id
+	return object, nil
+}
+
+// putSealedObject encodes a sealed access and sends it to the IO Provider, either as a "Put" or an
+// "Update".
+func (e *Encryptonize) putSealedAccess(access *data.SealedAccess, update bool) error {
+	var accessBuffer bytes.Buffer
+	enc := gob.NewEncoder(&accessBuffer)
+	if err := enc.Encode(access); err != nil {
+		return err
+	}
+
+	if update {
+		return e.ioProvider.Update(access.ID, io.DataTypeSealedAccess, accessBuffer.Bytes())
+	}
+	return e.ioProvider.Put(access.ID, io.DataTypeSealedAccess, accessBuffer.Bytes())
+}
+
+// getSealedObject fetches bytes from the IO Provider and decodes them into a sealed access.
+func (e *Encryptonize) getSealedAccess(id uuid.UUID) (*data.SealedAccess, error) {
+	accessBytes, err := e.ioProvider.Get(id, io.DataTypeSealedAccess)
+	if err != nil {
+		return nil, err
+	}
+
+	access := &data.SealedAccess{}
+	dec := gob.NewDecoder(bytes.NewReader(accessBytes))
+	err = dec.Decode(access)
+	if err != nil {
+		return nil, err
+	}
+
+	access.ID = id
+	return access, nil
 }


### PR DESCRIPTION
### Description

This PR implements the IO Provider interface as specified in the sec arch, as well as two basic implementations of the interface:
* An in-memory IO provider mainly meant for testing.
* An IO provider backed by [bbolt](https://github.com/etcd-io/bbolt) which can be used to store encrypted data in a local file. 

### Relevant Issues/PRs

Closes DEV-176

### Type(s) of Change (Split the PR if you check many)

- [ ] Added user feature
- [x] Added technical feature
- [x] Added tests
- [ ] Refactor
- [ ] Bugfix
- [x] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist

- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist

- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [x] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
